### PR TITLE
/* Source: xerbla.f */

### DIFF
--- a/acm782/cgeqpb.c
+++ b/acm782/cgeqpb.c
@@ -280,7 +280,7 @@ static integer c__3 = 3;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("CGEQPB", &i__1);
+	xerbla("CGEQPB", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/cgeqpx.c
+++ b/acm782/cgeqpx.c
@@ -234,7 +234,7 @@
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("CGEQPX", &i__1);
+	xerbla("CGEQPX", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/cgeqpy.c
+++ b/acm782/cgeqpy.c
@@ -235,7 +235,7 @@
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("CGEQPY", &i__1);
+	xerbla("CGEQPY", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/cmylap.c
+++ b/acm782/cmylap.c
@@ -150,7 +150,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("CGEQPF", &i__1);
+	xerbla("CGEQPF", &i__1, 6);
 	return 0;
     }
 
@@ -411,7 +411,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("CGEQRF", &i__1);
+	xerbla("CGEQRF", &i__1, 6);
 	return 0;
     }
 
@@ -624,7 +624,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("CGEQR2", &i__1);
+	xerbla("CGEQR2", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/ctrqpx.c
+++ b/acm782/ctrqpx.c
@@ -240,7 +240,7 @@ static integer c__0 = 0;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("CTRQPX", &i__1);
+	xerbla("CTRQPX", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/ctrqpy.c
+++ b/acm782/ctrqpy.c
@@ -240,7 +240,7 @@ static integer c__0 = 0;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("CTRQPY", &i__1);
+	xerbla("CTRQPY", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/ctrqyc.c
+++ b/acm782/ctrqyc.c
@@ -223,7 +223,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("CTRQYC", &i__1);
+	xerbla("CTRQYC", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/ctrrnk.c
+++ b/acm782/ctrrnk.c
@@ -100,7 +100,7 @@ static integer c__1 = 1;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("CTRRNK", &i__1);
+	xerbla("CTRRNK", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/dgeqpb.c
+++ b/acm782/dgeqpb.c
@@ -276,7 +276,7 @@ static integer c__3 = 3;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("DGEQPB", &i__1);
+	xerbla("DGEQPB", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/dgeqpx.c
+++ b/acm782/dgeqpx.c
@@ -231,7 +231,7 @@
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("DGEQPX", &i__1);
+	xerbla("DGEQPX", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/dgeqpy.c
+++ b/acm782/dgeqpy.c
@@ -232,7 +232,7 @@
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("DGEQPY", &i__1);
+	xerbla("DGEQPY", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/dmylap.c
+++ b/acm782/dmylap.c
@@ -145,7 +145,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("DGEQPF", &i__1);
+	xerbla("DGEQPF", &i__1, 6);
 	return 0;
     }
 
@@ -402,7 +402,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("DGEQRF", &i__1);
+	xerbla("DGEQRF", &i__1, 6);
 	return 0;
     }
 
@@ -611,7 +611,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("DGEQR2", &i__1);
+	xerbla("DGEQR2", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/dtrqpx.c
+++ b/acm782/dtrqpx.c
@@ -245,7 +245,7 @@ static integer c__0 = 0;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("DTRQPX", &i__1);
+	xerbla("DTRQPX", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/dtrqpy.c
+++ b/acm782/dtrqpy.c
@@ -245,7 +245,7 @@ static integer c__0 = 0;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("DTRQPY", &i__1);
+	xerbla("DTRQPY", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/dtrqyc.c
+++ b/acm782/dtrqyc.c
@@ -219,7 +219,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("DTRQYC", &i__1);
+	xerbla("DTRQYC", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/dtrrnk.c
+++ b/acm782/dtrrnk.c
@@ -96,7 +96,7 @@ static integer c__1 = 1;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("DTRRNK", &i__1);
+	xerbla("DTRRNK", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/sgeqpb.c
+++ b/acm782/sgeqpb.c
@@ -274,7 +274,7 @@ static integer c__3 = 3;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("SGEQPB", &i__1);
+	xerbla("SGEQPB", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/sgeqpx.c
+++ b/acm782/sgeqpx.c
@@ -232,7 +232,7 @@
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("SGEQPX", &i__1);
+	xerbla("SGEQPX", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/sgeqpy.c
+++ b/acm782/sgeqpy.c
@@ -232,7 +232,7 @@
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("SGEQPY", &i__1);
+	xerbla("SGEQPY", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/smylap.c
+++ b/acm782/smylap.c
@@ -144,7 +144,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("SGEQPF", &i__1);
+	xerbla("SGEQPF", &i__1, 6);
 	return 0;
     }
 
@@ -401,7 +401,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("SGEQRF", &i__1);
+	xerbla("SGEQRF", &i__1, 6);
 	return 0;
     }
 
@@ -610,7 +610,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("SGEQR2", &i__1);
+	xerbla("SGEQR2", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/strqpx.c
+++ b/acm782/strqpx.c
@@ -245,7 +245,7 @@ static integer c__0 = 0;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("STRQPX", &i__1);
+	xerbla("STRQPX", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/strqpy.c
+++ b/acm782/strqpy.c
@@ -245,7 +245,7 @@ static integer c__0 = 0;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("STRQPY", &i__1);
+	xerbla("STRQPY", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/strqyc.c
+++ b/acm782/strqyc.c
@@ -218,7 +218,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("STRQYC", &i__1);
+	xerbla("STRQYC", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/strrnk.c
+++ b/acm782/strrnk.c
@@ -96,7 +96,7 @@ static integer c__1 = 1;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("STRRNK", &i__1);
+	xerbla("STRRNK", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/zgeqpb.c
+++ b/acm782/zgeqpb.c
@@ -280,7 +280,7 @@ static integer c__3 = 3;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("ZGEQPB", &i__1);
+	xerbla("ZGEQPB", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/zgeqpx.c
+++ b/acm782/zgeqpx.c
@@ -236,7 +236,7 @@
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("ZGEQPX", &i__1);
+	xerbla("ZGEQPX", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/zgeqpy.c
+++ b/acm782/zgeqpy.c
@@ -236,7 +236,7 @@
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("ZGEQPY", &i__1);
+	xerbla("ZGEQPY", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/zmylap.c
+++ b/acm782/zmylap.c
@@ -150,7 +150,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("ZGEQPF", &i__1);
+	xerbla("ZGEQPF", &i__1, 6);
 	return 0;
     }
 
@@ -412,7 +412,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("ZGEQRF", &i__1);
+	xerbla("ZGEQRF", &i__1, 6);
 	return 0;
     }
 
@@ -625,7 +625,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("ZGEQR2", &i__1);
+	xerbla("ZGEQR2", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/ztrqpx.c
+++ b/acm782/ztrqpx.c
@@ -241,7 +241,7 @@ static integer c__0 = 0;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("ZTRQPX", &i__1);
+	xerbla("ZTRQPX", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/ztrqpy.c
+++ b/acm782/ztrqpy.c
@@ -241,7 +241,7 @@ static integer c__0 = 0;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("ZTRQPY", &i__1);
+	xerbla("ZTRQPY", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/ztrqyc.c
+++ b/acm782/ztrqyc.c
@@ -225,7 +225,7 @@ static integer c__2 = 2;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("ZTRQYC", &i__1);
+	xerbla("ZTRQYC", &i__1, 6);
 	return 0;
     }
 

--- a/acm782/ztrrnk.c
+++ b/acm782/ztrrnk.c
@@ -100,7 +100,7 @@ static integer c__1 = 1;
     }
     if (*info != 0) {
 	i__1 = -(*info);
-	xerbla("ZTRRNK", &i__1);
+	xerbla("ZTRRNK", &i__1, 6);
 	return 0;
     }
 


### PR DESCRIPTION
#define xerbla FORTRAN_WRAPPER(xerbla)
extern void xerbla(
    const char   *srname,
    const ptrdiff_t *info,
    const ptrdiff_t srname_len
);

Definition for xerbla function from Matlab2021b wants three input arguments. Assuming srname_len is simply the length of srname the function calls were modified to fit the definition.